### PR TITLE
Change png decoding function to support png files that have no alpha

### DIFF
--- a/src/tile/base.ts
+++ b/src/tile/base.ts
@@ -93,7 +93,7 @@ abstract class BaseTile {
    */
   private getValueFromPNG(binary: Uint8Array, tile: number[], lng: number, lat: number): number {
     const pngImage = PNG.load(binary);
-    const pixels = pngImage.decodePixels();
+    const pixels = pngImage.decode();
     const rgba = this.pixels2rgba(pixels, tile, lng, lat);
     // console.log(rgba)
     const height = this.calc(rgba[0], rgba[1], rgba[2], rgba[3]);


### PR DESCRIPTION
We are using PNG tiles which have only RGB and not have Alpha.
However, this library treats these as RGBA files.
Hence, I changed the PNG decoding function to treat these correctly.