### PR TITLE
added tms support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ const elevation = await trgb.getElevation([30.0529622, -1.9575129], 15);
 console.log(elevation);
 ```
 
-TMS(Tiled Map Service) tiles are also supported with
+TMS(Tile Map Service) tiles are also supported with
 
 ```ts
-const trgb = new TerrainRGB(url, 512, 5, 15, true)
+const trgb = new TerrainRGB(url, 512, 5, 15, true);
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -24,10 +24,19 @@ import {TerrainRGB} from '@watergis/terrain-rgb';
 
 const url = 'https://wasac.github.io/rw-terrain/tiles/{z}/{x}/{y}.png';
 const trgb = new TerrainRGB(url, 512);
+
 const elevation = await trgb.getElevation([30.0529622, -1.9575129], 15);
 console.log(elevation);
 ```
 
+TMS(Tiled Map Service) tiles are also supported with
+
+```ts
+const trgb = new TerrainRGB(url, 512, 5, 15, true)
+```
+
+
 If it can't find tile, it will return 404 error.
 
 If its terrain RGB tilesets was resampled by gdal2tiles, the result of elevation might not be the same with original DEM image.
+

--- a/src/tile/base.ts
+++ b/src/tile/base.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import { WebpMachine, loadBinaryData } from 'webp-hero';
-import { lngLatToGoogle } from 'global-mercator';
+import { lngLatToGoogle,lngLatToTile } from 'global-mercator';
 import PNG from '../png';
 
 /**
@@ -11,6 +11,8 @@ abstract class BaseTile {
 
   protected tileSize: number;
 
+  protected tms: boolean;
+
   protected minzoom: number;
 
   protected maxzoom: number;
@@ -19,12 +21,14 @@ abstract class BaseTile {
    * Constructor
    * @param url URL for terrain RGB raster tilesets
    * @param tileSize size of tile. 256 or 512
+   * @param tms whether it is Tile Map Service
    * @param minzoom minzoom for terrain RGB raster tilesets
    * @param maxzoom maxzoom for terrain RGB raster tilesets
    */
-  constructor(url: string, tileSize: number, minzoom: number, maxzoom: number) {
+  constructor(url: string, tileSize: number, tms: boolean, minzoom: number, maxzoom: number) {
     this.url = url;
     this.tileSize = tileSize;
+    this.tms = tms;
     this.minzoom = minzoom;
     this.maxzoom = maxzoom;
   }
@@ -46,7 +50,7 @@ abstract class BaseTile {
       } else if (z < this.minzoom) {
         zoom = this.minzoom;
       }
-      const tile = lngLatToGoogle([lng, lat], zoom);
+      const tile = this.tms?lngLatToTile([lng, lat], zoom):lngLatToGoogle([lng, lat], zoom);
       const url: string = this.url
         .replace(/{x}/g, tile[0].toString())
         .replace(/{y}/g, tile[1].toString())

--- a/src/tile/base.ts
+++ b/src/tile/base.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import { WebpMachine, loadBinaryData } from 'webp-hero';
-import { lngLatToGoogle,lngLatToTile } from 'global-mercator';
+import { lngLatToGoogle, lngLatToTile } from 'global-mercator';
 import PNG from '../png';
 
 /**
@@ -11,26 +11,26 @@ abstract class BaseTile {
 
   protected tileSize: number;
 
-  protected tms: boolean;
-
   protected minzoom: number;
 
   protected maxzoom: number;
+
+  protected tms: boolean;
 
   /**
    * Constructor
    * @param url URL for terrain RGB raster tilesets
    * @param tileSize size of tile. 256 or 512
-   * @param tms whether it is Tile Map Service
    * @param minzoom minzoom for terrain RGB raster tilesets
    * @param maxzoom maxzoom for terrain RGB raster tilesets
+   * @param tms whether it is Tile Map Service
    */
-  constructor(url: string, tileSize: number, tms: boolean, minzoom: number, maxzoom: number) {
+  constructor(url: string, tileSize: number, minzoom: number, maxzoom: number, tms: boolean) {
     this.url = url;
     this.tileSize = tileSize;
-    this.tms = tms;
     this.minzoom = minzoom;
     this.maxzoom = maxzoom;
+    this.tms = tms;
   }
 
   /**
@@ -50,7 +50,7 @@ abstract class BaseTile {
       } else if (z < this.minzoom) {
         zoom = this.minzoom;
       }
-      const tile = this.tms?lngLatToTile([lng, lat], zoom):lngLatToGoogle([lng, lat], zoom);
+      const tile = this.tms ? lngLatToTile([lng, lat], zoom) : lngLatToGoogle([lng, lat], zoom);
       const url: string = this.url
         .replace(/{x}/g, tile[0].toString())
         .replace(/{y}/g, tile[1].toString())

--- a/src/tile/base.ts
+++ b/src/tile/base.ts
@@ -131,7 +131,7 @@ abstract class BaseTile {
         const height = this.getValueFromPNG(buffer, tile, lng, lat);
         resolve(height);
       })
-          .catch((err) => reject(err));
+        .catch((err) => reject(err));
     });
   }
 

--- a/src/tile/base.ts
+++ b/src/tile/base.ts
@@ -57,9 +57,9 @@ abstract class BaseTile {
       }
       const tile = this.tms ? lngLatToTile([lng, lat], zoom) : lngLatToGoogle([lng, lat], zoom);
       const url: string = this.url
-          .replace(/{x}/g, tile[0].toString())
-          .replace(/{y}/g, tile[1].toString())
-          .replace(/{z}/g, tile[2].toString());
+        .replace(/{x}/g, tile[0].toString())
+        .replace(/{y}/g, tile[1].toString())
+        .replace(/{z}/g, tile[2].toString());
       let ext = this.getUrlExtension(url);
       // console.log(ext)
       if (!ext) {
@@ -70,20 +70,20 @@ abstract class BaseTile {
           axios.get(url, {
             responseType: 'arraybuffer',
           })
-              .then((res) => {
-                const binary = Buffer.from(res.data, 'binary');
-                const value = this.getValueFromPNG(binary, tile, lng, lat);
-                resolve(value);
-              })
-              .catch((err) => reject(err));
+            .then((res) => {
+              const binary = Buffer.from(res.data, 'binary');
+              const value = this.getValueFromPNG(binary, tile, lng, lat);
+              resolve(value);
+            })
+            .catch((err) => reject(err));
           break;
         case 'webp':
           loadBinaryData(url)
-              .then((binary) => {
-                this.getValueFromWEBP(binary, tile, lng, lat).then((value: number) => {
-                  resolve(value);
-                }).catch((err) => reject(err));
+            .then((binary) => {
+              this.getValueFromWEBP(binary, tile, lng, lat).then((value: number) => {
+                resolve(value);
               }).catch((err) => reject(err));
+            }).catch((err) => reject(err));
           break;
         default:
           reject(new Error(`Invalid file extension: ${ext}`));
@@ -118,10 +118,10 @@ abstract class BaseTile {
    * @returns the value calculated from coordinates
    */
   private getValueFromWEBP(
-      binary: Uint8Array,
-      tile: number[],
-      lng: number,
-      lat: number,
+    binary: Uint8Array,
+    tile: number[],
+    lng: number,
+    lat: number,
   ): Promise<number> {
     // eslint-disable-next-line no-unused-vars
     return new Promise((resolve: (value:number)=>void, reject: (reason?: any) => void) => {

--- a/src/tile/base.ts
+++ b/src/tile/base.ts
@@ -18,8 +18,6 @@ abstract class BaseTile {
 
   protected maxzoom: number;
 
-  protected tms: boolean;
-
   /**
    * Constructor
    * @param url URL for terrain RGB raster tilesets

--- a/src/tile/terrainrgb.ts
+++ b/src/tile/terrainrgb.ts
@@ -8,11 +8,12 @@ class TerrainRGB extends BaseTile {
    * Constructor
    * @param url URL for terrain RGB raster tilesets
    * @param tileSize size of tile. 256 or 512
+   * @param tms whether it is Tile Map Service
    * @param minzoom minzoom for terrain RGB raster tilesets. default is 5
    * @param maxzoom maxzoom for terrain RGB raster tilesets. default is 15
    */
-  constructor(url: string, tileSize: number, minzoom = 5, maxzoom = 15) {
-    super(url, tileSize, minzoom, maxzoom);
+  constructor(url: string, tileSize: number, tms:boolean = false, minzoom = 5, maxzoom = 15) {
+    super(url, tileSize, tms, minzoom, maxzoom);
   }
 
   /**

--- a/src/tile/terrainrgb.ts
+++ b/src/tile/terrainrgb.ts
@@ -12,8 +12,8 @@ class TerrainRGB extends BaseTile {
    * @param minzoom minzoom for terrain RGB raster tilesets. default is 5
    * @param maxzoom maxzoom for terrain RGB raster tilesets. default is 15
    */
-  constructor(url: string, tileSize: number, tms:boolean = false, minzoom = 5, maxzoom = 15) {
-    super(url, tileSize, tms, minzoom, maxzoom);
+  constructor(url: string, tileSize: number, minzoom = 5, maxzoom = 15, tms = false) {
+    super(url, tileSize, minzoom, maxzoom, tms);
   }
 
   /**


### PR DESCRIPTION
TMS url support added by using ```lngLatToTile()``` in package [global-mercator](https://www.npmjs.com/package/global-mercator) 


since my custom terrain tile for MapLibre GL JS is TMS, I needed to add function for this library.